### PR TITLE
Add the dynamic keyword to the autonaming page

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/auto-naming.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/auto-naming.adoc
@@ -4,7 +4,7 @@
 _@Since **Payara Server 5.193**_
 
 The auto-naming feature is an _asadmin_ feature added to help with the naming of instances,
-deployment groups, and other resources by resolving name conflicts and auto-generating names.
+deployment groups, and other resources by resolving name conflicts and auto-generating names for dynamic resources.
 
 [[usage]]
 == Usage


### PR DESCRIPTION
This should make it easier to find the docs using the "dynamic" keyword.

Same in Community docs: https://github.com/payara/Payara-Community-Documentation/pull/41