### PR TITLE
Prepared for the 5.21.0 release

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,12 +1,12 @@
 name: docs
 title: Payara Platform Documentation
-version: master
+version: 5.21.0
 start_page: ROOT:README.adoc
 nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    currentVersion: '5.20.0'
+    currentVersion: '5.21.0'
     glassfishVersion: '5'
     payaraWebDtd: 'https://raw.githubusercontent.com/payara/Payara-Enterprise-Documentation/master/docs/modules/ROOT/pages/schemas/payara-web-app_4.dtd'
     payaraResourcesDtd: 'https://raw.githubusercontent.com/payara/Payara-Enterprise-Documentation/master/docs/modules/ROOT/pages/schemas/payara-resources_1_6.dtd'
@@ -18,8 +18,8 @@ asciidoc:
     mpHealthSpecUrl: 'https://github.com/eclipse/microprofile-health/releases/tag/2.2'
     mpFaultToleranceVersion: '2.1'
     mpFaultToleranceSpecUrl: 'https://github.com/eclipse/microprofile-fault-tolerance/releases/tag/2.1'
-    mpJwtVersion: '1.1'
-    mpJwtSpecUrl: 'https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1'
+    mpJwtVersion: '1.1.1'
+    mpJwtSpecUrl: 'https://github.com/eclipse/microprofile-jwt-auth/releases/tag/1.1.1'
     mpOpenTracingVersion: '1.3'
     mpOpenTracingSpecUrl: 'https://github.com/eclipse/microprofile-opentracing/releases/tag/1.3'
     mpOpenAPIVersion: '1.1'

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,7 +2,7 @@
 * xref:README.adoc[Introduction]
 ** xref:general-info/general-info.adoc[Overview]
 ** xref:release-notes/README.adoc[Release Notes]
-*** xref:release-notes/release-notes-20-0.adoc[Payara Enterprise 5.20.0 Release Notes]
+*** xref:release-notes/release-notes-21-0.adoc[Payara Enterprise 5.21.0 Release Notes]
 ** xref:security/security.adoc[Security]
 *** xref:security/security-fix-list.adoc[Security Fixes Summary]
 ** xref:general-info/supported-platforms.adoc[Supported Platforms]

--- a/docs/modules/ROOT/pages/release-notes/README.adoc
+++ b/docs/modules/ROOT/pages/release-notes/README.adoc
@@ -8,4 +8,5 @@ Detailed information about features and fixes in every release.
 
 *2020*
 
+* 2020 July - xref:release-notes/release-notes-21-0.adoc[Payara Enterprise 5.21.0]
 * 2020 June - xref:release-notes/release-notes-20-0.adoc[Payara Enterprise 5.20.0]

--- a/docs/modules/ROOT/pages/release-notes/release-notes-21-0.adoc
+++ b/docs/modules/ROOT/pages/release-notes/release-notes-21-0.adoc
@@ -1,0 +1,39 @@
+== Supported APIs and Applications
+
+* Java EE 8 Applications
+* MicroProfile 3.3
+* Jakarta EE 8 Applications
+
+== Improvements
+
+* [https://github.com/payara/Payara/pull/4769[FISH-31]] - HTTP/2 Support for JDK Native ALPN APIs
+* [https://github.com/payara/Payara/pull/4761[FISH-148]] - Support multirelease JARs in WARs
+* [https://github.com/payara/Payara/pull/4744[FISH-151]] - Implement MicroProfile JWT-Auth 1.1.1
+* [https://github.com/payara/Payara/pull/4731[FISH-171]] - Support for multi HTTPAuthenticationMechanism
+* [https://github.com/payara/Payara-Enterprise/pull/108[FISH-185]] - Add set-network-listener-security-configuration Command
+* [https://github.com/payara/Payara/pull/4776[FISH-186]] - Admin Console Integration for Certificate Management
+* [https://github.com/payara/Payara/pull/4746[FISH-187]] - Make domain_name Parameter domainname in Cert Management Commands
+* [FISH-189] - Add Warning when Adding to Certificate to the Keystore
+* [https://github.com/payara/Payara/pull/4757[FISH-191]] - Add Additional Help Text to Cert Management Commands
+* [FISH-192] - Add --reload Parameter to Certificate Management Commands
+* [https://github.com/payara/Payara/pull/4739[FISH-205]] - Allow dynamic reconfiguration of log levels for Payara Micro instance
+* [https://github.com/payara/Payara/pull/4699[FISH-208]] - Improvements in stop-domain process
+* [https://github.com/payara/Payara/pull/4773[FISH-219]] - Indicate missing default value when using custom template for create-domain
+
+== Bug Fixes
+
+* [https://github.com/payara/Payara/pull/4747[FISH-188]] - Fix Adding PEMs with Add-to-keystore and Add-to-truststore Commands
+* [https://github.com/payara/Payara/pull/4753[FISH-190]] - Missing Help Text for Certificate Management Commands
+* [https://github.com/payara/Payara/pull/4743[FISH-195]] - Missing --nodedir and --node Options on Certificate Management Commands
+* [https://github.com/payara/Payara/pull/4748[FISH-197]] - JDBCRealm requires the Message Digest field although a default value should be used
+* [https://github.com/payara/Payara/pull/4747[FISH-200]] - generate-self-signed-certificate places a PrivateKeyEntry in the Truststore
+* [https://github.com/payara/Payara/pull/4728[FISH-207]] - Disabling applications via their deployment group targets not working
+* [https://github.com/payara/Payara/pull/4705[FISH-211]] - PayaraMicro APIs not initializable when run via RootLauncher
+* [https://github.com/payara/Payara/pull/4747[FISH-216]] - Add-to-keystore and add-to-truststore Commands don't add CA signed certs correctly
+* [https://github.com/payara/Payara/pull/4756[FISH-236]] - GitHub #4688 Typo in docker file - removal of /tmp/tmpfile
+* [https://github.com/payara/Payara/pull/4774[FISH-260]] - Missing invocation on top of invocation stack
+* [https://github.com/payara/Payara/pull/4738[FISH-263]] - Community Contribution: NPE when enabling versioned application with Microprofile Config
+
+== Component Upgrades
+
+* [https://github.com/payara/Payara/pull/4767[FISH-243]] - Update Monitoring Console Process to 1.2.1

--- a/docs/modules/ROOT/pages/release-notes/release-notes-history.adoc
+++ b/docs/modules/ROOT/pages/release-notes/release-notes-history.adoc
@@ -2,6 +2,3 @@
 = Appendix: History of release notes
 
 Detailed information about features and fixes in every release.
-
-
-* 2020 June - xref:release-notes/release-notes-20-0.adoc[Payara Server 5.20.0]


### PR DESCRIPTION
I've removed the list of versions in the release notes history page to mimic what's in the Community docs. It's just one more place that links to the release notes and it's not worth to maintain it.