### PR TITLE
Remove claim of supporting OpenJ9

### DIFF
--- a/docs/modules/ROOT/pages/general-info/supported-platforms.adoc
+++ b/docs/modules/ROOT/pages/general-info/supported-platforms.adoc
@@ -15,7 +15,6 @@ The Payara Platform currently supports the following Java Virtual Machines:
 * Oracle JDK: 8 (u162+), 11 (11.0.5+)
 * Amazon Corretto: 8, 11 (11.0.5+)
 * Adopt Open JDK: 8, 11 (11.0.5+)
-* Adopt Open JDK with Eclipse Open J9: 8, 11 (11.0.5+)
 
 The Payara Platform currently supports the `x64` and `arm64` variants of the above JVMs. Payara Enterprise customers can request support for other CPU architecture variants.
 


### PR DESCRIPTION
At least until we resolve the blocking issues with OpenJ9.

For more details, see QACI-346.