### PR TITLE
Fixes for JLine event expansion in Enterprise

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -63,7 +63,7 @@
 *** xref:documentation/payara-server/asadmin-commands/misc-commands.adoc[Miscellaneous Commands]
 *** xref:documentation/payara-server/asadmin-commands/disabling-jline.adoc[Disabling JLine]
 *** xref:documentation/payara-server/asadmin-commands/auto-naming.adoc[Auto-Naming]
-*** xref:documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc[Enable JLine Event Expansion]
+*** xref:documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc[Disable JLine Event Expansion]
 ** xref:documentation/payara-server/rest-api/rest-api-documentation.adoc[REST API Documentation]
 *** xref:documentation/payara-server/rest-api/overview.adoc[Overview]
 *** xref:documentation/payara-server/rest-api/security.adoc[Security]

--- a/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc
@@ -1,14 +1,15 @@
-= Enable JLine Event Expansion
+= Disable JLine Event Expansion
 
-This feature enables using the Event Designators inside the Asadmin Multimode. 
+This feature disables using the Event Designators inside the Asadmin Multimode.
 
 An https://www.gnu.org/software/bash/manual/html_node/Event-Designators.html[Event Designator] is a reference to a command line entry in the history list.
 
-This is enabled by default. 
+Event Designators are enabled by default. 
 
 NOTE: If this feature is enabled, all `\` characters are treated as escape characters and they are removed before running the command. If you need to pass `\` into an asadmin command, you need to escape it and turn it into `\\`. This needs to be done even if you enclose the string in quotes.
 
-== Enabling JLine Event Expansion
+== Disabling JLine Event Expansion
+
 Set the environment variable `+AS_ADMIN_DISABLE_EVENT_EXPANSION+` to `+false+` 
 
 === For Linux

--- a/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc
@@ -6,7 +6,7 @@ An https://www.gnu.org/software/bash/manual/html_node/Event-Designators.html[Eve
 
 Event Designators are enabled by default. 
 
-NOTE: If this feature is disabled, the `\` characters are not treated as escape characters when parsing the command and they are retained when running the command. The default behavior will treat them as escape characters and if you need to pass `\` into an asadmin command, you would need to escape it and turn it into `\\`. If event expansion is disabled, all `\` are passed to Payara Server without any change.
+NOTE: If this feature is disabled, the `\` characters are not treated as escape characters when parsing the command and they are retained when running the command. The default behavior would treat them as escape characters and if you need to pass `\` into an asadmin command, you would need to escape it and turn it into `\\`. If event expansion is disabled, all `\` are passed to Payara Server without any change.
 
 == Disabling JLine Event Expansion
 

--- a/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/asadmin-commands/Enable-JLine-Event-Expansion.adoc
@@ -6,7 +6,7 @@ An https://www.gnu.org/software/bash/manual/html_node/Event-Designators.html[Eve
 
 Event Designators are enabled by default. 
 
-NOTE: If this feature is enabled, all `\` characters are treated as escape characters and they are removed before running the command. If you need to pass `\` into an asadmin command, you need to escape it and turn it into `\\`. This needs to be done even if you enclose the string in quotes.
+NOTE: If this feature is disabled, the `\` characters are not treated as escape characters when parsing the command and they are retained when running the command. The default behavior will treat them as escape characters and if you need to pass `\` into an asadmin command, you would need to escape it and turn it into `\\`. If event expansion is disabled, all `\` are passed to Payara Server without any change.
 
 == Disabling JLine Event Expansion
 


### PR DESCRIPTION
There are changes in the default behavior between editions, which weren't properly reflected in the docs.