### PR TITLE
FISH 5697 Documentation

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/h2/h2.adoc
@@ -4,7 +4,7 @@
 H2 is a Java-based Database which replaced Derby as the default database in Payara 5. Derby as a database service that can be started and managed by Payara Server Enterprise, has been removed starting from version 5.201.
 
 
-Starting from _Payara 5.2021.8_ H2 Database is started with a password, this password is `changeit`. This change is due to upgrading H2 Database to version 1.4.200 and does not affect how you start/stop the database or how you connect to the H2 Console.
+Starting from _Payara 5.32.0_ H2 Database is started with a password, this password is `changeit`. This change is due to upgrading H2 Database to version 1.4.200 and does not affect how you start/stop the database or how you connect to the H2 Console.
 
 [[why-replace-derby]]
 == Why replace Derby?


### PR DESCRIPTION
Added some documentation around H2 Database being started with the password `changeit` instead of it previously starting with no password. 