### PR TITLE
FISH-5811 Upgrade Santuario to version 2.2.3

### DIFF
--- a/docs/modules/ROOT/pages/security/security-fix-list.adoc
+++ b/docs/modules/ROOT/pages/security/security-fix-list.adoc
@@ -9,6 +9,8 @@ can or have impacted Payara Server across releases:
 |=======================================================================
 |ID |CVSS v3.0 Base Score |Status |Summary |Release |Observations
 
+| https://nvd.nist.gov/vuln/detail/CVE-2021-40690/[CVE-2021-40690] | 7.5 | FIXED | The "secureValidation" property is not passed correctly when creating a KeyInfo from a KeyInfoReference element, allowing abuse of an XPath Transform to extract any local .xml files in a RetrievalMethod element. | 5.34.0 | Fixed by upgrading Apache Santuario to 2.2.3
+
 | https://www.cvedetails.com/cve/CVE-2018-10054/[CVE-2018-10054] | 6.5 | FIXED | Remote code execution vulnerability in H2 DB because CREATE ALIAS can execute arbitrary Java code | 5.32.0 | Fixed by upgrading H2 DB to 1.4.200
 
 | https://www.cvedetails.com/cve/CVE-2018-14335/[CVE-2018-14335] | 4.0 | FIXED |  Insecure handling of permissions in the backup function of the H2 DB | 5.32.0 | Fixed by upgrading H2 DB to 1.4.200


### PR DESCRIPTION
Adds the CVE and fix information for [CVE-2021-40690](https://nvd.nist.gov/vuln/detail/CVE-2021-40690#vulnCurrentDescriptionTitle)