### PR TITLE
FISH-5878 PayaraConstants for JAX-RS certificate aliases

### DIFF
--- a/docs/modules/ROOT/pages/documentation/ecosystem/jax-rs-extension.adoc
+++ b/docs/modules/ROOT/pages/documentation/ecosystem/jax-rs-extension.adoc
@@ -15,21 +15,29 @@ To enable this we need to include the next dependency on the application
 
 Also it is needed to specify the next property for Rest Client call
 
-[cols="1,1", options="header"]
+[cols="1,1,1", options="header"]
 |===
 |Property
+|Payara xref:documentation/payara-server/public-api/README.adoc[Public API] constant
 |Description
 
 |`fish.payara.jaxrs.client.certificate.alias`
+| `PayaraConstants.JAXRS_CLIENT_CERTIFICATE_ALIAS`
 | The alias name of the certificate
 
 |===
+
+NOTE: The name of the property is defined as a constant in the `fish.payara.security.client.PayaraConstants` class.
 
 ==== Example
 
 [source, java]
 ----
-ClientBuilder.newBuilder().property("fish.payara.jaxrs.client.certificate.alias", "someAliasName").build()
-.target(new URI("https://localhost:8080/service")).request().get(Service.class)
+ClientBuilder.newBuilder()
+  .property(PayaraConstants.JAXRS_CLIENT_CERTIFICATE_ALIAS, "someAliasName")
+  .build()
+  .target(new URI("https://localhost:8080/service"))
+  .request().get(Service.class)
 ----
+
 NOTE: For this to work, you need to include the certificate with the given alias in the default payara keystore.

--- a/docs/modules/ROOT/pages/documentation/microprofile/rest-client.adoc
+++ b/docs/modules/ROOT/pages/documentation/microprofile/rest-client.adoc
@@ -94,35 +94,42 @@ You can define the certificate alias rest client will use with one of the follow
 [cols="1,1", options="header"]
 |===
 |Property
+|Payara xref:documentation/payara-server/public-api/README.adoc[Public API] constant
 |Description
 
 |`fish.payara.rest.client.certificate.alias`
+| `PayaraConstants.REST_CLIENT_CERTIFICATE_ALIAS`
 | The alias name of the certificate
 
 |===
+
+NOTE: The name of the property is defined as a constant in the `fish.payara.security.client.PayaraConstants` class.
 
 ==== Example
 
 [source, java]
 ----
-RestClientBuilder.newBuilder().baseUri(new URI("https://localhost:8080/service")).property("fish.payara.rest.client.certificate.alias", "someAliasName").build(Service.class);
+RestClientBuilder.newBuilder()
+  .baseUri(new URI("https://localhost:8080/service"))
+  .property(PayaraConstants.REST_CLIENT_CERTIFICATE_ALIAS, "someAliasName")
+  .build(Service.class);
 ----
 
 * Adding with MicroProfile Config
 
-[cols="1,1", options="header"]
+[cols="1,1,1", options="header"]
 |===
 |Property
+|Payara xref:documentation/payara-server/public-api/README.adoc[Public API] constant
 |Description
 
 |`payara.certificate.alias`
+| `PayaraConstants.MP_CONFIG_CLIENT_CERTIFICATE_ALIAS`
 | The alias name of the certificate
 
 |===
 
-In this case you don't need to add it during the Rest Client Call
-
-You can find out more about MicroProfile Config property here: xref:documentation/microprofile/config/README.adoc[MicroProfile Config]
+You can define the alias globally as a xref:documentation/microprofile/config/README.adoc[MicroProfile config] property, either in an application-specific config source only for a single application, or with a global config source for all applicaitons. In this case you don't need to add it during every single Rest Client call.
 
 NOTE: For this to work, you need to include the certificate with the given alias in the default payara keystore.
 


### PR DESCRIPTION
FISH-5878 has been released for Enterprise edition. We just missed to document it. I'll copy the documentation also to the v35 branch.