### PR TITLE
FISH-5748 Alter OpenID Connect Doc

### DIFF
--- a/docs/modules/ROOT/pages/documentation/payara-server/public-api/openid-connect-support.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/public-api/openid-connect-support.adoc
@@ -487,8 +487,6 @@ When fields, which are lists (e.g. `scopesSupported`, `responseTypesSupported`),
 
 The client secret can be input directly, or for added security it can be aliased using any of the following features:
 
-- xref:/documentation/payara-server/password-aliases/README.adoc[Password Aliases]
-- xref:/documentation/payara-server/server-configuration/var-substitution/README.adoc[Environment Variables / System Properties]
 - xref:/documentation/microprofile/config/README.adoc[Config API]
 
 [[fetch-caller-data]]

--- a/docs/modules/ROOT/pages/documentation/payara-server/public-api/openid-connect-support.adoc
+++ b/docs/modules/ROOT/pages/documentation/payara-server/public-api/openid-connect-support.adoc
@@ -485,9 +485,9 @@ When fields, which are lists (e.g. `scopesSupported`, `responseTypesSupported`),
 [[secret-alias]]
 == Client Secret Aliasing
 
-The client secret can be input directly, or for added security it can be aliased using any of the following features:
+The client secret can be input directly, or for added security it can be aliased using xref:/documentation/microprofile/config/README.adoc[Microprofile Config]
 
-- xref:/documentation/microprofile/config/README.adoc[Config API]
+NOTE: Environment Variables and System Properties can be used indirectly through MicroProfile Config.
 
 [[fetch-caller-data]]
 == Fetch Caller Data


### PR DESCRIPTION
Tested what variables I can use.

## Can be used
* MP Config Properties (`${MPCONFIG=payara.security.openid.clientId`)
* Expression Language (`#{testBean.clientId}`)

## Can't be used
* Password Aliases 
* Environment Variables / System Properties